### PR TITLE
Fixed an issue with get() and count() in models and tests

### DIFF
--- a/models/engine/db_storage.py
+++ b/models/engine/db_storage.py
@@ -53,6 +53,9 @@ class DBStorage:
 
     def get(self, cls, id):
         """retrieve one object of a class with its id"""
+        if cls is None or cls.__name__ not in classes:
+            return None
+
         objs = self.__session.query(cls).all()
         for obj in objs:
             if id == obj.id:
@@ -61,7 +64,7 @@ class DBStorage:
 
     def count(self, cls=None):
         """count the number of objects in storage"""
-        objs = self.__session.query(cls).all()
+        objs = self.all(cls)
         all_count = len(objs)
         return (all_count)
 

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -132,7 +132,7 @@ class TestDbStorage(unittest.TestCase):
         obj.save()
         models.storage.reload()
         all_count = models.storage.count()
-        expected_count = 1
+        expected_count = len(models.storage.all())
         self.assertEqual(all_count, expected_count)
 
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
@@ -144,5 +144,5 @@ class TestDbStorage(unittest.TestCase):
         obj.save()
         models.storage.reload()
         cls_count = models.storage.count(State)
-        expected_count = 2
+        expected_count = len(models.storage.all(State))
         self.assertEqual(cls_count, expected_count)


### PR DESCRIPTION
Use the models.storage.all() to get count for all objects, I noticed the code was failing when I added a class to it later It is all working fine now.